### PR TITLE
Create Format.py

### DIFF
--- a/Format.py
+++ b/Format.py
@@ -1,0 +1,20 @@
+# coding = utf-8
+
+import os
+import re
+import sys
+
+output_location = "./"
+for root, dirs, files in os.walk(sys.argv[1]):
+    for file in files:
+        if re.match("^.*\\.java$", file) is not None:
+            print(os.path.join(root, file))
+            in_file = open(os.path.join(root, file), "r")
+            out_file = open(os.path.join(output_location, file), "w")
+            for code in in_file:
+                if re.match("^package[.\n]*", code):
+                    continue
+                if re.match("^import[.\n]*", code) and not re.match("^import java[.\n]*", code):
+                    continue
+                out_file.write(code)
+            out_file.close()


### PR DESCRIPTION
自动拆包脚本
用法：
`python Format.py [src]`
将`[src]`及其子目录下的`.java`代码提取出来，删除其中的`package`以及**非java开头的**`import`语句，并输出到Format.py所在的目录下
#2 